### PR TITLE
Sanitize file paths in FileHub modules

### DIFF
--- a/brelynt-electron/filehub-agent.js
+++ b/brelynt-electron/filehub-agent.js
@@ -39,21 +39,33 @@ app.get('/api/tree', (req, res) => {
 
 // Прочитать файл
 app.get('/api/file', (req, res) => {
-    const filePath = path.join(ROOT_DIR, req.query.path);
+    const normalized = path.normalize(req.query.path || '');
+    const filePath = path.resolve(ROOT_DIR, normalized);
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
     if (!fs.existsSync(filePath)) return res.status(404).send('Not found');
     res.send(fs.readFileSync(filePath, 'utf-8'));
 });
 
 // Записать (изменить или создать) файл
 app.post('/api/file', (req, res) => {
-    const filePath = path.join(ROOT_DIR, req.query.path);
+    const normalized = path.normalize(req.query.path || '');
+    const filePath = path.resolve(ROOT_DIR, normalized);
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
     fs.writeFileSync(filePath, req.body.content, 'utf-8');
     res.send('OK');
 });
 
 // Удалить файл
 app.delete('/api/file', (req, res) => {
-    const filePath = path.join(ROOT_DIR, req.query.path);
+    const normalized = path.normalize(req.query.path || '');
+    const filePath = path.resolve(ROOT_DIR, normalized);
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
     if (!fs.existsSync(filePath)) return res.status(404).send('Not found');
     fs.unlinkSync(filePath);
     res.send('Deleted');

--- a/brelynt-electron/filehub.js
+++ b/brelynt-electron/filehub.js
@@ -44,14 +44,22 @@ app.get('/api/tree', (req, res) => {
 
 // --- API: получить файл ---
 app.get('/api/file', (req, res) => {
-    const filePath = path.join(ROOT_DIR, req.query.path);
+    const normalized = path.normalize(req.query.path || '');
+    const filePath = path.resolve(ROOT_DIR, normalized);
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
     if (!fs.existsSync(filePath)) return res.status(404).send('Not found');
     res.send(fs.readFileSync(filePath, 'utf-8'));
 });
 
 // --- API: сохранить файл ---
 app.post('/api/file', (req, res) => {
-    const filePath = path.join(ROOT_DIR, req.query.path);
+    const normalized = path.normalize(req.query.path || '');
+    const filePath = path.resolve(ROOT_DIR, normalized);
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
     if (!fs.existsSync(filePath)) return res.status(404).send('Not found');
     fs.writeFileSync(filePath, req.body.content);
     res.send('OK');


### PR DESCRIPTION
## Summary
- sanitize all incoming paths in filehub.js and filehub-agent.js
- reject requests that try to escape ROOT_DIR

## Testing
- `node -c brelynt-electron/filehub.js`
- `node -c brelynt-electron/filehub-agent.js`

------
https://chatgpt.com/codex/tasks/task_e_684aa4d7cae0832e97ea20c46349e6fe