### PR TITLE
Implement peer handshake announcements

### DIFF
--- a/brelynt-electron/p2p-server.js
+++ b/brelynt-electron/p2p-server.js
@@ -10,9 +10,15 @@ wss.on('connection', ws => {
         if (msg.type === "join") {
             peers.push({ ws, name: msg.name });
             broadcast({ type: "peers", peers: peers.map(p => p.name) });
+            // информируем остальных о новом участнике
+            broadcast({ type: "handshake", name: msg.name }, ws);
         }
         if (msg.type === "tx") {
             broadcast({ type: "tx", tx: msg.tx }, ws);
+        }
+        if (msg.type === "handshake") {
+            // пересылаем рукопожатие другим участникам
+            broadcast({ type: "handshake", name: msg.name }, ws);
         }
     });
     ws.on('close', () => {

--- a/brelynt-electron/public/p2p.js
+++ b/brelynt-electron/public/p2p.js
@@ -2,13 +2,15 @@
 
 let peers = [];
 let ws = null;
+let myName = localStorage.getItem('brelynt-name') || 'User';
+const handshaked = new Set();
 
 function startP2P(serverAddr = "ws://localhost:9090") {
     ws = new WebSocket(serverAddr);
 
     ws.onopen = () => {
         console.log("P2P: соединение установлено.");
-        ws.send(JSON.stringify({ type: "join", name: "User" }));
+        ws.send(JSON.stringify({ type: "join", name: myName }));
     };
 
     ws.onmessage = (event) => {
@@ -19,6 +21,13 @@ function startP2P(serverAddr = "ws://localhost:9090") {
         }
         if (msg.type === "tx") {
             addRemoteTx(msg.tx);
+        }
+        if (msg.type === "handshake") {
+            console.log("Handshake от", msg.name);
+            if (msg.name !== myName && !handshaked.has(msg.name)) {
+                handshaked.add(msg.name);
+                ws.send(JSON.stringify({ type: "handshake", name: myName }));
+            }
         }
     };
 


### PR DESCRIPTION
## Summary
- broadcast new peer presence in the P2P server
- relay handshake messages between peers
- let client react to handshake events and respond once

## Testing
- `npm test --prefix brelynt-electron` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aa4d9f9d8832ea04a20193d6695dd