### PR TITLE
Fix script source path for P2P module

### DIFF
--- a/brelynt-electron/public/index.html
+++ b/brelynt-electron/public/index.html
@@ -456,7 +456,7 @@
     window.breadcrumbNav = breadcrumbNav;
 
   </script>
-<script src="../js/p2p.js"></script>
+<script src="p2p.js"></script>
 <script>
   startP2P("ws://localhost:9090");
 </script></body>


### PR DESCRIPTION
## Summary
- fix HTML script path for p2p module

## Testing
- `npm install`
- `npm start` *(fails: Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_684a9d6f18a0832ea5bfb6b55b2bf626