### PR TITLE
Secure filehub paths

### DIFF
--- a/brelynt-electron/filehub-agent.js
+++ b/brelynt-electron/filehub-agent.js
@@ -1,4 +1,6 @@
 // filehub-agent.js
+// Usage: run `node filehub-agent.js` to expose a minimal file API on port 3040
+// limited to the `public` directory.
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
@@ -39,22 +41,38 @@ app.get('/api/tree', (req, res) => {
 
 // Прочитать файл
 app.get('/api/file', (req, res) => {
-    const filePath = path.join(ROOT_DIR, req.query.path);
-    if (!fs.existsSync(filePath)) return res.status(404).send('Not found');
+    const requested = path.normalize(req.query.path || '');
+    const filePath = path.resolve(ROOT_DIR, requested);
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
+    if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+        return res.status(404).send('Not found');
+    }
     res.send(fs.readFileSync(filePath, 'utf-8'));
 });
 
 // Записать (изменить или создать) файл
 app.post('/api/file', (req, res) => {
-    const filePath = path.join(ROOT_DIR, req.query.path);
+    const requested = path.normalize(req.query.path || '');
+    const filePath = path.resolve(ROOT_DIR, requested);
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
     fs.writeFileSync(filePath, req.body.content, 'utf-8');
     res.send('OK');
 });
 
 // Удалить файл
 app.delete('/api/file', (req, res) => {
-    const filePath = path.join(ROOT_DIR, req.query.path);
-    if (!fs.existsSync(filePath)) return res.status(404).send('Not found');
+    const requested = path.normalize(req.query.path || '');
+    const filePath = path.resolve(ROOT_DIR, requested);
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
+    if (!fs.existsSync(filePath)) {
+        return res.status(404).send('Not found');
+    }
     fs.unlinkSync(filePath);
     res.send('Deleted');
 });

--- a/brelynt-electron/filehub.js
+++ b/brelynt-electron/filehub.js
@@ -1,4 +1,6 @@
 // filehub.js
+// Usage: run `node filehub.js` to start a small HTTP API on port 3040
+// for browsing and editing files inside the `public` directory.
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
@@ -44,15 +46,27 @@ app.get('/api/tree', (req, res) => {
 
 // --- API: получить файл ---
 app.get('/api/file', (req, res) => {
-    const filePath = path.join(ROOT_DIR, req.query.path);
-    if (!fs.existsSync(filePath)) return res.status(404).send('Not found');
+    const requested = path.normalize(req.query.path || '');
+    const filePath = path.resolve(ROOT_DIR, requested);
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
+    if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+        return res.status(404).send('Not found');
+    }
     res.send(fs.readFileSync(filePath, 'utf-8'));
 });
 
 // --- API: сохранить файл ---
 app.post('/api/file', (req, res) => {
-    const filePath = path.join(ROOT_DIR, req.query.path);
-    if (!fs.existsSync(filePath)) return res.status(404).send('Not found');
+    const requested = path.normalize(req.query.path || '');
+    const filePath = path.resolve(ROOT_DIR, requested);
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
+    if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+        return res.status(404).send('Not found');
+    }
     fs.writeFileSync(filePath, req.body.content);
     res.send('OK');
 });


### PR DESCRIPTION
## Summary
- normalize paths before file read/write
- reject invalid requests outside ROOT_DIR
- add brief usage notes to filehub scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a9d71825c832eb29d510bee312168