### PR TITLE
Fix release zip archive creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: zip -r web4.zip .
+      - run: git archive --format=zip -o web4.zip HEAD
       - uses: softprops/action-gh-release@v1
         with:
           files: web4.zip


### PR DESCRIPTION
## Summary
- use `git archive` instead of `zip` in the release workflow to exclude repository metadata

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `npm test` in `Brelynt` *(fails: missing script `test`)*
- `npm test` in `brelynt-electron` *(fails: missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684aef633100832e8e4bb97eb5421494