### PR TITLE
Ignore backup folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ desktop.ini
 
 # Backup files
 backup/
+*_backup/
 full-backup.ps1
 
 # IDE/project files


### PR DESCRIPTION
## Summary
- ignore any `_backup/` folders so archived copies in `brelynt-electron/_backup` aren't tracked

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aef64525c832e82ae66b1a07ddec5