### PR TITLE
Add BRELYNT_PATH env variable

### DIFF
--- a/brelynt-electron/main.js
+++ b/brelynt-electron/main.js
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, ipcMain, Menu, dialog } = require('electron');
 const path = require('path');
 const fs = require('fs-extra');
+let BRELYNT_PATH = process.env.BRELYNT_PATH;
 
 function createWindow () {
   Menu.setApplicationMenu(null);


### PR DESCRIPTION
## Summary
- read `BRELYNT_PATH` from the environment in `brelynt-electron/main.js`

## Testing
- `npm test` *(fails: missing `package.json`)*
- `npm test` in `brelynt-electron` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_684aef649f84832eb5c81f542a3644ed