### PR TITLE
Fix file path validation

### DIFF
--- a/brelynt-electron/filehub-agent.js
+++ b/brelynt-electron/filehub-agent.js
@@ -41,13 +41,18 @@ app.get('/api/tree', (req, res) => {
 
 // Прочитать файл
 app.get('/api/file', (req, res) => {
-
+    const requestedPath = req.query.path || '';
+    const filePath = path.resolve(ROOT_DIR, requestedPath);
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
     res.send(fs.readFileSync(filePath, 'utf-8'));
 });
 
 // Записать (изменить или создать) файл
 app.post('/api/file', (req, res) => {
-
+    const requestedPath = req.body.path || '';
+    const filePath = path.resolve(ROOT_DIR, requestedPath);
     if (!filePath.startsWith(ROOT_DIR)) {
         return res.status(400).send('Invalid path');
     }
@@ -57,7 +62,11 @@ app.post('/api/file', (req, res) => {
 
 // Удалить файл
 app.delete('/api/file', (req, res) => {
-
+    const requestedPath = req.body.path || '';
+    const filePath = path.resolve(ROOT_DIR, requestedPath);
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
     fs.unlinkSync(filePath);
     res.send('Deleted');
 });


### PR DESCRIPTION
## Summary
- ensure file paths for filehub-agent.js come from the request
- check that requested files reside under ROOT_DIR

## Testing
- `node --check brelynt-electron/filehub-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_684aef65ef40832e9a83e466a08974c7