### PR TITLE
Fix file path handling in filehub

### DIFF
--- a/brelynt-electron/filehub.js
+++ b/brelynt-electron/filehub.js
@@ -46,13 +46,19 @@ app.get('/api/tree', (req, res) => {
 
 // --- API: получить файл ---
 app.get('/api/file', (req, res) => {
-
+    const filePath = path.resolve(ROOT_DIR, req.query.path || '');
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
     res.send(fs.readFileSync(filePath, 'utf-8'));
 });
 
 // --- API: сохранить файл ---
 app.post('/api/file', (req, res) => {
-
+    const filePath = path.resolve(ROOT_DIR, req.body.path || '');
+    if (!filePath.startsWith(ROOT_DIR)) {
+        return res.status(400).send('Invalid path');
+    }
     fs.writeFileSync(filePath, req.body.content);
     res.send('OK');
 });


### PR DESCRIPTION
## Summary
- ensure file path is derived from `ROOT_DIR` in filehub API
- reject paths outside the allowed directory

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aef675718832e99c2f38ad572cd3d