### PR TITLE
Fix p2p.js inclusion path

### DIFF
--- a/brelynt-electron/public/index.html
+++ b/brelynt-electron/public/index.html
@@ -456,7 +456,7 @@
     window.breadcrumbNav = breadcrumbNav;
 
   </script>
-<script src="../js/p2p.js"></script>
+<script src="p2p.js"></script>
 <script>
   startP2P("ws://localhost:9090");
 </script></body>


### PR DESCRIPTION
## Summary
- fix relative path for p2p script in public/index.html

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aa4d72234832eabc43fb9cc97cd24