### PR TITLE
Make install-buy-module path configurable

### DIFF
--- a/brelynt-electron/install-buy-module.ps1
+++ b/brelynt-electron/install-buy-module.ps1
@@ -1,6 +1,19 @@
 # install-buy-module.ps1 — Windows PowerShell 5.x совместимость
 
-$AppDir    = "D:\BrelyntApp\brelynt-electron"
+<#
+Usage:
+    .\install-buy-module.ps1 [-AppDir <path>]
+
+The optional **-AppDir** parameter sets the target directory of the Brelynt
+Electron application. If omitted, the script checks the `BRELYNT_APPDIR`
+environment variable. When neither is provided, the directory
+`$PSScriptRoot\brelynt-electron` is used by default.
+#>
+
+param(
+    [string]$AppDir = $(if ($env:BRELYNT_APPDIR) { $env:BRELYNT_APPDIR } else { "$PSScriptRoot\brelynt-electron" })
+)
+
 $Frontend  = "$AppDir\index.html"
 $BuyJS     = "$AppDir\buyToken.js"
 $BuyCSS    = "$AppDir\buyToken.css"


### PR DESCRIPTION
## Summary
- make `$AppDir` a parameter with an environment variable fallback
- document script usage in a comment

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dac2059c4832e8e9e6290305f0ba5